### PR TITLE
fix extensions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ module.exports = {
         func: {
           // default ['i18next.t', 'i18n.t']
           list: ['t', '$t', 'i18next.t', 'i18n.t'],
-          // default ['js', 'jsx', 'vue']
-          extensions: ['js', 'jsx']
+          // default ['.js', '.jsx', '.vue']
+          extensions: ['.js', '.jsx']
         },
         lngs: ['en', 'de'],
         // both defaults to {{lng}}/{{ns}}.json
@@ -43,6 +43,7 @@ module.exports = {
 ```
 
 **Minimal setup:**
+
 ```javascript
 const path = require('path');
 const i18nextWebpackPlugin = require('i18next-scanner-webpack');


### PR DESCRIPTION
Hello!

When trying the plugin, I came across this problem where locale files would come out empty but using i18next-scanner directly would work.

I found out that extensions in the configuration need the dot to work with i18next-scanner, I updated the README to reflect that.