### PR TITLE
Fix: dist -> dest in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module.exports = {
     new i18nextWebpackPlugin({
       // See options at https://github.com/i18next/i18next-scanner#options
       // src defaults to ./src
-      // dist defaults to ./locales
+      // dest defaults to ./locales
       options: {
         func: {
           // default ['i18next.t', 'i18n.t']
@@ -68,7 +68,7 @@ module.exports = {
 | Name    | Description                                    | default   | Optional |
 | ------- | ---------------------------------------------- | --------- | -------- |
 | src     | source path of files with i18next translations | ./src     | yes      |
-| dist    | destination of translation files               | ./locales | yes      |
+| dest    | destination of translation files               | ./locales | yes      |
 | options | all options                                    |           | yes      |
 
 Available options: [here](https://www.i18next.com/configuration-options.html)


### PR DESCRIPTION
The documentation incorrectly stated that the key for the destination of translation files was "dist", when the code checks for dest
https://github.com/ph1p/i18next-scanner-webpack/blob/0dacbc037139ed55e474317f32fba5177456daa0/index.js#L84